### PR TITLE
add(YanjunChen): add EMNLP2024 paper on the accuracy paradox in reward modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ format:
   - Code: [Official](https://github.com/OpenRLHF/OpenRLHF/blob/main/examples/scripts/train_reinforce_llama_ray.sh)
 
 ### 2024
+- [The Accuracy Paradox in RLHF: When Better Reward Models Don't Yield Better Language Models](https://aclanthology.org/2024.emnlp-main.174/)
+  - Yanjun Chen, Dawei Zhu, Yirong Sun, Xinghao Chen, Wei Zhang, Xiaoyu Shen
+  - Keyword: Reward Model Evaluation, Accuracy Paradox, LLM Alignment
+  - Code: [Official](https://github.com/EIT-NLP/AccuracyParadox-RLHF)
+
 - [Align Anything: Training All-Modality Models to Follow Instructions with Language Feedback](https://arxiv.org/abs/2412.15838)
   - Jiaming Ji, Jiayi Zhou, Hantao Lou, Boyuan Chen, Donghai Hong, Xuyao Wang, Wenqi Chen, Kaile Wang, Rui Pan, Jiahao Li, Mohan Wang, Josef Dai, Tianyi Qiu, Hua Xu, Dong Li, Weipeng Chen, Jun Song, Bo Zheng, Yaodong Yang
   - Keyword: Multi-modality Alignment, Dataset, Training-evaluation Framework


### PR DESCRIPTION
### ✨ What’s New

This PR adds the EMNLP 2024 paper:

- **"The Accuracy Paradox in RLHF: When Better Reward Models Don't Yield Better Language Models"**  
  - Authors: Yanjun Chen, Dawei Zhu, Yirong Sun, Xinghao Chen, Wei Zhang, Xiaoyu Shen
  - Link: https://aclanthology.org/2024.emnlp-main.174/  
  - Keywords: Reward Model Evaluation, Accuracy Paradox, LLM Alignment
  - Code: [official](https://github.com/EIT-NLP/AccuracyParadox-RLHF)

### 🧠 Why This Matters

While most papers in RLHF focus on improving reward model architectures or training frameworks, this paper critically examines a foundational assumption: **that better reward model accuracy leads to better aligned LLMs**.

It demonstrates — both theoretically and empirically — that **higher validation accuracy on reward models may correlate negatively** with RLHF outcomes, depending on data distributions and reward variance. This insight challenges current evaluation practices and calls for more robust reward validation metrics.

Adding this paper introduces a **valuable epistemic counterweight** to a repository largely focused on positive results and frameworks. It enriches the theoretical spectrum of RLHF and helps prevent overconfidence in standard RM validation.

### 📌 Where It Was Added

- Under the **2024** section of the `Papers` list.
