### PR TITLE
doc(heybshin): add more recent papers and fix duplicate entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,17 @@ format:
 - [Improving Reinforcement Learning from Human Feedback with Efficient Reward Model Ensemble](https://arxiv.org/abs/2401.16635v2)
   - Shun Zhang, Zhenfang Chen, Sunli Chen, Yikang Shen, Zhiqing Sun, Chuang Gan
   - Keywords: RLHF, Reward Ensemble, Efficient Ensemble Method
+  
+- [RIME: Robust Preference-based Reinforcement Learning with Noisy Human Preferences](https://arxiv.org/abs/2402.17257)
+  - Jie Cheng, Gang Xiong, Xingyuan Dai, Qinghai Miao, Yisheng Lv, Fei-Yue Wang
+  - Keyword: 
+  - Code: [official](https://github.com/CJReinforce/RIME_ICML2024)
+  
+- [Uni-RLHF: Universal Platform and Benchmark Suite for Reinforcement Learning with Diverse Human Feedback](https://arxiv.org/abs/2402.02423)
+  - Yifu Yuan, Jianye Hao, Yi Ma, Zibin Dong, Hebin Liang, Jinyi Liu, Zhixin Feng, Kai Zhao, Yan Zheng
+  - Keyword: 
+  - Code: [official](https://github.com/pickxiguapi/Uni-RLHF-Platform)
+  - Dataset: [official](https://uni-rlhf.github.io/)
 
 ### 2023
 - [The Trickle-down Impact of Reward (In-)consistency on RLHF](https://arxiv.org/abs/2309.16155)
@@ -365,11 +376,6 @@ format:
   - Yann Dubois, Chen Xuechen Li, Rohan Taori, Tianyi Zhang, Ishaan Gulrajani, Jimmy Ba, Carlos Guestrin, Percy S. Liang, Tatsunori B. Hashimoto
   - Keyword: RLHF, Simulation Framework
   - Code: [official](https://github.com/tatsu-lab/alpaca_farm)
-
-- [Preference Ranking Optimization for Human Alignment](https://arxiv.org/pdf/2306.17492)
-  - Feifan Song, Bowen Yu, Minghao Li, Haiyang Yu, Fei Huang, Yongbin Li, Houfeng Wang
-  - Keyword: Preference Ranking Optimization
-  - Code: [official](github.com/AlibabaResearch/DAMO-ConvAI/tree/main/PRO)
 
 - [Adversarial Preference Optimization](https://arxiv.org/abs/2311.08045)
   - Pengyu Cheng, Yifan Yang, Jian Li, Yong Dai, Nan Du
@@ -441,7 +447,7 @@ format:
   - Jian Hu, Li Tao, June Yang, Chandler Zhou
   - Keyword: Decision Transformer-based Alignment, Offline Reinforcement Learning, RLHF System
 
-- [Preference Ranking Optimization for Human Alignment](https://arxiv.org/pdf/2306.17492.pdf)
+- [Preference Ranking Optimization for Human Alignment](https://arxiv.org/pdf/2306.17492)
   - Feifan Song, Bowen Yu, Minghao Li, Haiyang Yu, Fei Huang, Yongbin Li and Houfeng Wang
   - Keyword: Supervised Human Preference Alignment, Preference Ranking Extension
   - Code: [official](https://github.com/AlibabaResearch/DAMO-ConvAI/tree/main/PRO)

--- a/README.md
+++ b/README.md
@@ -562,6 +562,13 @@ format:
   - Joseph Early, Tom Bewley, Christine Evers, Sarvapali Ramchurn
   - Keyword: Reward Modelling (RLHF), Non-Markovian, Multiple Instance Learning, Interpretability
   - Code: [official](https://github.com/JAEarly/MIL-for-Non-Markovian-Reward-Modelling)
+- [SURF: Semi-supervised Reward Learning with Data Augmentation for Feedback-efficient Preference-based Reinforcement Learning](https://arxiv.org/abs/2203.10050)
+  - Jongjin Park, Younggyo Seo, Jinwoo Shin, Honglak Lee, Pieter Abbeel, Kimin Lee
+  - Keyword: Semi-supervised Reward Learning, Preference Data Augmentation, RLHF Efficiency
+- [Reward Uncertainty for Exploration in Preference-based Reinforcement Learning](https://arxiv.org/abs/2205.12401)
+  - Xinran Liang, Katherine Shu, Kimin Lee, Pieter Abbeel
+  - Keyword: Preference-based RL (PbRL), Exploration, Reward Uncertainty, Feedback Efficiency
+  - Code: [official](https://github.com/rll-research/rune)
 
 ### 2021
 - [WebGPT: Browser-assisted question-answering with human feedback](https://arxiv.org/abs/2112.09332) (WebGPT)
@@ -577,6 +584,14 @@ format:
   - Keyword:  The success of policy gradient is because of reward rather than the shape of output distribution, Machine Translation, NMT, DOmain Adaption
   - Code: [official](https://github.com/samuki/reinforce-joey)
   - Dataset: [WMT15](https://www.statmt.org/wmt15/index.html), [IWSLT14](https://sites.google.com/site/iwsltevaluation2014/mt-track)
+- [PEBBLE: Feedback-Efficient Interactive Reinforcement Learning via Relabeling Experience and Unsupervised Pre-training](https://arxiv.org/abs/2106.05091)
+  - Kimin Lee, Laura Smith, Pieter Abbeel
+  - Keyword: Preference-based RL (PbRL), Data Efficiency, Unsupervised Pretraining, Reward Relabeling
+  - Code: [official](https://github.com/rll-research/BPref)
+- [B-Pref: Benchmarking Preference-Based Reinforcement Learning](https://arxiv.org/abs/2111.03026)
+  - Kimin Lee, Laura Smith, Anca Dragan, Pieter Abbeel
+  - Keyword: Benchmark, Preference-based RL, Simulated Human Feedback, Robustness Evaluation
+  - Code: [official](https://github.com/rll-research/BPref)
 
 ### 2020 and before
 


### PR DESCRIPTION
### Summary
Adds 2 recent RLHF resources and cleans up duplicates with minor fixes:

- **RIME (2024)** — robust preference-based RL with noisy human feedback.
- **Uni-RLHF (2024)** — universal platform + benchmark suite for diverse feedback.

Links verified, formatting follows repo conventions.