### PR TITLE
Request for adding paper: Eliminating Inductive Bias in Reward Models with Information-Theoretic Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ format:
 ### 2025
 
 - [Eliminating Inductive Bias in Reward Models with Information-Theoretic Guidance](https://arxiv.org/pdf/2512.23461)
+  - Alibaba
   - Zhuo Li, Pengyu Cheng, Zhechao Yu, Feifei Tong, Anningzhe Gao, Tsung-Hui Chang, Xiang Wan, Erchao Zhao, Xiaoxi Jiang, Guanjun Jiang
   - Keyword: Debiased Reward Model, Reward Hacking, RLHF, Mutual Information
   - Code: [Official](https://github.com/Qwen-Applications/DIR)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ format:
 
 ### 2025
 
+- [Eliminating Inductive Bias in Reward Models with Information-Theoretic Guidance](https://arxiv.org/pdf/2512.23461)
+  - Zhuo Li, Pengyu Cheng, Zhechao Yu, Feifei Tong, Anningzhe Gao, Tsung-Hui Chang, Xiang Wan, Erchao Zhao, Xiaoxi Jiang, Guanjun Jiang
+  - Keyword: Debiased Reward Model, Reward Hacking, RLHF, Mutual Information
+  - Code: [Official](https://github.com/Qwen-Applications/DIR)
+    
 - [Position: The Complexity of Perfect AI Alignment -- Formalizing the RLHF Trilemma](https://arxiv.org/abs/2511.19504)
   - Subramanyam Sahoo, Aman Chadha, Vinija Jain, Divya Chaudhary
   - Keyword: Alignment Bias, Safety, Interpretability


### PR DESCRIPTION
Dear Authors,

We sincerely thank you for maintaining awesome-RLHF code repo. We would like to recommend our work, DIR (Debiasing via Information optimization), for inclusion: "Eliminating Inductive Bias in Reward Models with Information-Theoretic Guidance" https://arxiv.org/abs/2512.23461.

In this paper, we propose a novel method called DIR (Debiasing via Information optimization). Inspired by the Information Bottleneck principle, DIR decouples preferences from biased attributes by maximizing mutual information (MI) with human feedback while minimizing MI with spurious features. Beyond the theoretical framework, DIR has been rigorously validated in large-scale industrial scenarios and successfully integrated into our production development.

We believe this information-theoretic perspective offers a robust solution to RM bias, and we would be honored if you could include it in your repo. Thank you for considering this request.

