### PR TITLE
Add BGPT REFUTE (scientific critique & epistemic calibration benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,10 @@ format:
 
 Our purpose is to make this repo even better. If you are interested in contributing, please refer to [HERE](CONTRIBUTING.md) for instructions in contribution.
 
+## Benchmarks (community addition)
+
+- [REFUTE](https://huggingface.co/datasets/BGPT-OFFICIAL/refute) — Apache-2.0 benchmark for scientific critique and epistemic calibration (falsification, limitations, overclaims, missing-evidence refusal, calibration, planted-flaw detection). [Leaderboard](https://huggingface.co/spaces/BGPT-OFFICIAL/refute-leaderboard) · [Technical report](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/TECHNICAL_REPORT.md) · [Integrations](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/tree/main/integrations)
+
 ## License
 
 Awesome RLHF is released under the Apache 2.0 license.


### PR DESCRIPTION
Adds [REFUTE](https://huggingface.co/datasets/BGPT-OFFICIAL/refute), an Apache-2.0 Hugging Face benchmark for scientific critique and epistemic calibration on recent science paper summaries. Includes Inspect AI + lm-eval integrations and a public leaderboard.